### PR TITLE
Add option to output to console

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ application:
      ]},
 
      {logstasher, [
-         {transport, udp},     % tcp | udp
+         {transport, udp},     % tcp | udp | console
          {host, "localhost"},  % inet:hostname()
          {port, 5000}          % inet:port_number()
      ]}


### PR DESCRIPTION
Containers often log to console, where a transport picks up the output for shipping to logstash.

This adds the transport `console` to cover this use case.