### PR TITLE
Map 'undefined' to 'null'

### DIFF
--- a/src/logstasher.erl
+++ b/src/logstasher.erl
@@ -125,11 +125,11 @@ maybe_send(Data, State) ->
     end.
 
 -spec send(binary(), maps:map()) -> ok | {error, atom()}.
+send(Data, #{transport := console}) ->
+    io:put_chars([ Data, "\n"]);
 send(_Data, #{socket := undefined}) ->
     {error, closed};
 send(Data, #{transport := tcp, socket := Socket}) ->
     gen_tcp:send(Socket, Data);
 send(Data, #{transport := udp, socket := Socket, host := Host, port := Port}) ->
-    gen_udp:send(Socket, Host, Port, Data);
-send(Data, #{transport := console}) ->
-    io:put_chars([ Data, "\n"]).
+    gen_udp:send(Socket, Host, Port, Data).

--- a/src/logstasher_h.erl
+++ b/src/logstasher_h.erl
@@ -57,7 +57,8 @@ safe_field({Key, Value}) when is_list(Key) ->
     safe_field({list_to_binary(Key), Value}).
 
 -spec safe_value(term()) -> jsx:json_term().
-safe_value(Pid) when is_pid(Pid) -> list_to_binary(pid_to_list(Pid));
+safe_value(Pid) when is_pid(Pid) ->
+    list_to_binary(pid_to_list(Pid));
 safe_value(List) when is_list(List) ->
     case io_lib:char_list(List) of
         true ->
@@ -65,6 +66,8 @@ safe_value(List) when is_list(List) ->
         false ->
             lists:map(fun safe_value/1, List)
     end;
+safe_value(undefined) ->
+    null;
 safe_value(Val) when is_binary(Val); is_atom(Val); is_integer(Val) ->
     Val;
 safe_value(Val) ->


### PR DESCRIPTION
In the metadata it is quite common to have `undefined` values.

This patch maps those values to `null`, this prevents them to be mapped to the string `"undefined"`.

Also add a patch for the console output.
